### PR TITLE
Fix boundary check in MapMatrix

### DIFF
--- a/MapMatrix.cpp
+++ b/MapMatrix.cpp
@@ -4,6 +4,18 @@
 
 #include "MapMatrix.h"
 
+bool MapMatrix::isInMatrix(unsigned int row, unsigned int col) {
+    if (row >= m_map.size()) {
+        return false;
+    }
+
+    if (col >= m_map.at(0).size()) {
+        return false;
+    }
+
+    return true;
+}
+
 MapMatrix::MapMatrix(unsigned int width, unsigned int height) {
     if (width > 0 && height > 0) {
 
@@ -25,21 +37,21 @@ MapMatrix::MapMatrix(unsigned int width, unsigned int height) {
 
 
 Map *MapMatrix::getValue(unsigned int row, unsigned int col) {
-    if (row, col) {
+    if (isInMatrix(row, col)) {
         return m_map.at(row).at(col);
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 void MapMatrix::setValue(unsigned int row, unsigned int col, Map *value){
-    delete m_map.at(row).at(col); // delete the old tile to prevent memory leak
-    m_map.at(row).at(col) = value;
-
+    if (isInMatrix(row, col)) {
+        delete m_map.at(row).at(col); // delete the old tile to prevent memory leak
+        m_map.at(row).at(col) = value;
+    }
 }
 
 void MapMatrix::printOutMap(unsigned int row, unsigned int col) {
-    if (row, col) {
+    if (isInMatrix(row, col)) {
         m_map.at(row).at(col)->print();
     }
 }

--- a/MapMatrix.h
+++ b/MapMatrix.h
@@ -10,6 +10,7 @@
 
 class MapMatrix {
     std::vector<std::vector<Map *> > m_map;
+    bool isInMatrix(unsigned int row, unsigned int col);
 public:
     MapMatrix(unsigned int width, unsigned int height);
 


### PR DESCRIPTION
## Summary
- add a private `isInMatrix` helper to MapMatrix
- use the new check in `getValue`, `setValue`, and `printOutMap`

## Testing
- `g++ -std=c++14 -I. *.cpp -o dungeon`
- `./dungeon <<EOF
2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683f64cb013c8332b80286202c8510ed